### PR TITLE
Automate dependency updates and modernize release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,23 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,8 +1,6 @@
 name: release
 on:
   workflow_dispatch: # Only manual trigger and only for the main branch
-    branches:
-    - main
     inputs:
       bump_level:
         type: choice
@@ -19,57 +17,52 @@ permissions:
 
 jobs:
   build-and-publish:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release       # needed for PyPI OIDC
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
-        token: ${{ secrets.GIT_TOKEN_DANIEL}}
+        token: ${{ secrets.GIT_TOKEN_DANIEL }}  # admin token bypasses required checks on main
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: "3.12"
 
-    - name: Install dependencies
+    - name: Install Poetry
+      run: curl -sSL https://install.python-poetry.org | python3 - --version 1.8.3
+
+    - name: Bump version, tag and push
       run: |
-        curl -sSL https://install.python-poetry.org | python3 - --version 1.2.2
+        set -eu
+        BUMP_LEVEL='${{ github.event.inputs.bump_level }}'
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
 
-    - name: Build and publish
-      run: |
-        set -euv
-        
-        BUMP_LEVEL=${{ github.event.inputs.bump_level }}
-        echo "bump level: ${BUMP_LEVEL}"
-        git config --local user.email "Bumpversion"
-        git config --local user.name "Bumpversion"
-
-        # Version bump
-
-        NEW_VERSION=$(poetry version -s ${BUMP_LEVEL})
-        echo ${NEW_VERSION}
-        git add pyproject.toml poetry.lock
+        NEW_VERSION=$(poetry version -s "${BUMP_LEVEL}")
+        echo "New version: ${NEW_VERSION}"
+        git add pyproject.toml
         git commit -m "Bump version to ${NEW_VERSION}"
         git tag "v${NEW_VERSION}"
 
-        git push -f  
-        git push --tags -f
-        
-        poetry build
-        
+        git push origin HEAD:main
+        git push origin "v${NEW_VERSION}"
+
         echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
 
-    - uses: pypa/gh-action-pypi-publish@release/v1    # publish
-    - name: Create Release
-      uses: actions/create-release@v1
+    - name: Build distributions
+      run: poetry build
+
+    - uses: pypa/gh-action-pypi-publish@release/v1    # publish via OIDC
+
+    - name: Create GitHub Release with generated notes
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: v${{ env.NEW_VERSION }}
-        release_name: v${{ env.NEW_VERSION }}
-        body: |
-          pypi package: https://pypi.org/project/binarycookies/${{ env.NEW_VERSION }}/
-        draft: false
-        prerelease: false
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "v${NEW_VERSION}" \
+          --title "v${NEW_VERSION}" \
+          --generate-notes \
+          --notes "PyPI package: https://pypi.org/project/binarycookies/${NEW_VERSION}/"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- **Dependabot**: weekly cadence, minor+patch grouped into one PR, plus `github-actions` ecosystem.
- **Auto-merge**: approves + enables auto-merge (squash) for non-major Dependabot PRs; merges only after the required checks pass (ruleset on main will be updated to require the test matrix).
- **Release**: same manual bump-level dispatch, but no more `git push -f`, modern actions, and auto-generated release notes instead of a static body. OIDC publishing was already in place and is unchanged.