### PR TITLE
chore(docs): bump pymdown-extensions to ^11.0.1 (security)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1145,14 +1145,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.2"
 description = "Extension pack for Python Markdown."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["docs"]
 files = [
-    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
-    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
+    {file = "pymdown_extensions-11.0.2-py3-none-any.whl", hash = "sha256:259910762019732caa1dfd76f3faa62c59f191d46573e80bcb1d13c0f675bbe5"},
+    {file = "pymdown_extensions-11.0.2.tar.gz", hash = "sha256:9506fcbe66fa355a775b768084334238dd6805020ac4b92bea0c0dda6f8f223d"},
 ]
 
 [package.dependencies]
@@ -1580,4 +1580,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "0978f2d2cfdd8ccbeaf38afadb7c616dc15e7e137cecb27522651d21410bb218"
+content-hash = "73c551b266806703e7cbc53c1fdcb404621bd8aebb858b3f4fbe72043e579e30"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ mkdocs-gen-files = ">=0.4,<0.7"
 mkdocs-literate-nav = "^0.6.0"
 mkdocstrings = {extras = ["python"], version = ">=0.20,<0.31"}
 mkautodoc = "^0.2.0"
-pymdown-extensions = "^10.0.1"
+pymdown-extensions = "^11.0.1"
 
 [tool.poetry.scripts]
 bcparser = "binarycookies.__main__:main"


### PR DESCRIPTION
Resolves the last two open Dependabot alerts (GHSA-gm37-52c6-37mw high, GHSA-9xwg-3r6f-jcx2 medium). Fixes exist only in 11.0.1+, which `^10.0.1` excluded. Docs group only, not shipped; `mkdocs build --strict` passes locally on 11.0.2.